### PR TITLE
Fix for issue with hidden listview columns still having splitters in header

### DIFF
--- a/WebCPP/Controls/ListView/ListView.cpp
+++ b/WebCPP/Controls/ListView/ListView.cpp
@@ -429,6 +429,12 @@ namespace web
 		return header->getColumnCount() - 1;
 	}
 
+	void ListView::setColumnVisible(size_t index, bool visible)
+	{
+		header->setColumnVisible(index, visible);
+		onColumnsUpdated();
+	}
+
 	std::vector<std::string> ListView::columnNames() const
 	{
 		return header->columnNames();

--- a/WebCPP/Controls/ListView/ListViewBody.cpp
+++ b/WebCPP/Controls/ListView/ListViewBody.cpp
@@ -9,23 +9,32 @@ namespace web
 	ListViewBody::ListViewBody() : View("listviewbody-view")
 	{
 		auto layout = createGridLayout();
-		layout->setGap(0.0, 10.0);
+		layout->setGap(0.0, 0.0);
 	}
 
 	void ListViewBody::updateColumns(ListViewHeader* header)
 	{
-		std::vector<GridTrackSize> sizes;
-		for (size_t i = 0, count = header->getColumnCount(); i < count; i++)
+		size_t count = header->getColumnCount();
+
+		size_t lastVisible = count;
+		for (size_t i = 0; i < count; i++)
 		{
-			if (header->isColumnExpanding(i))
-			{
-				sizes.push_back(GridLayout::minmaxSize(header->getColumnWidth(i), GridLayout::autoSize));
-			}
-			else
-			{
-				sizes.push_back(header->getColumnWidth(i));
-			}
+			if (header->getColumnWidth(i) > 0.0 || header->isColumnExpanding(i))
+				lastVisible = i;
 		}
+
+		std::vector<GridTrackSize> sizes;
+		for (size_t i = 0; i < count; i++)
+		{
+			double width = header->getColumnWidth(i);
+			double gap = (lastVisible < count && i < lastVisible) ? 10.0 : 0.0;
+
+			if (header->isColumnExpanding(i))
+				sizes.push_back(GridLayout::minmaxSize(width + gap, GridLayout::autoSize));
+			else
+				sizes.push_back(width + gap);
+		}
+
 		getLayout<GridLayout>()->setColumns(sizes);
 	}
 

--- a/WebCPP/Controls/ListView/ListViewHeader.cpp
+++ b/WebCPP/Controls/ListView/ListViewHeader.cpp
@@ -37,6 +37,24 @@ namespace web
 		columns.push_back(col);
 	}
 
+	void ListViewHeader::setColumnVisible(size_t index, bool visible)
+	{
+		if (index >= columns.size())
+			return;
+
+		columns[index].visible = visible;
+		columns[index].label->setVisible(visible);
+
+		for (size_t i = 0, size = columns.size(); i < size; i++)
+		{
+			if (columns[i].splitter)
+			{
+				bool splitterVisible = columns[i].visible && (i + 1 < columns.size() ? columns[i + 1].visible : true);
+				columns[i].splitter->setVisible(splitterVisible);
+			}
+		}
+	}
+
 	std::vector<std::string> ListViewHeader::columnNames() const
 	{
 		std::vector<std::string> names;

--- a/WebCPP/Include/WebCPP/Controls/ListView/ListView.h
+++ b/WebCPP/Include/WebCPP/Controls/ListView/ListView.h
@@ -33,6 +33,7 @@ namespace web
 		void clearList();
 
 		int addColumn(std::string name, double width, bool expanding = false);
+		void setColumnVisible(size_t index, bool visible);
 
 		std::vector<std::string> columnNames() const;
 

--- a/WebCPP/Include/WebCPP/Controls/ListView/ListViewHeader.h
+++ b/WebCPP/Include/WebCPP/Controls/ListView/ListViewHeader.h
@@ -10,10 +10,11 @@ namespace web
 		ListViewHeader();
 
 		void addColumn(std::string name, double width, bool expanding);
+		void setColumnVisible(size_t index, bool visible);
 		size_t getColumnCount() const { return columns.size(); }
 
-		double getColumnWidth(size_t i) const { return columns[i].width; }
-		bool isColumnExpanding(size_t i) const { return columns[i].expanding; }
+		double getColumnWidth(size_t i) const { return columns[i].visible ? columns[i].width : 0.0; }
+		bool isColumnExpanding(size_t i) const { return columns[i].visible && columns[i].expanding; }
 
 		std::vector<std::string> columnNames() const;
 


### PR DESCRIPTION
When columns are hidden, the splitters of the columns are still shown in header. Dragging them causes weird rendering issues