### PR TITLE
closeModal() must pin this before detach()

### DIFF
--- a/WebCPP/Core/View.cpp
+++ b/WebCPP/Core/View.cpp
@@ -116,6 +116,7 @@ namespace web
 
 	void View::closeModal()
 	{
+		auto pin = shared_from_this();
 		detach();
 
 		if (!modalLayers.empty())


### PR DESCRIPTION
Since detaching releases the layout's shared_ptr which may be the last owner