### PR TITLE
Fixed listview issues for visible columns following hidden columns.

### DIFF
--- a/WebCPP/Controls/ListView/ListViewHeader.cpp
+++ b/WebCPP/Controls/ListView/ListViewHeader.cpp
@@ -49,8 +49,19 @@ namespace web
 		{
 			if (columns[i].splitter)
 			{
-				bool splitterVisible = columns[i].visible && (i + 1 < columns.size() ? columns[i + 1].visible : true);
-				columns[i].splitter->setVisible(splitterVisible);
+				bool hasNextVisible = false;
+				if (columns[i].visible)
+				{
+					for (size_t j = i + 1; j < size; j++)
+					{
+						if (columns[j].visible)
+						{
+							hasNextVisible = true;
+							break;
+						}
+					}
+				}
+				columns[i].splitter->setVisible(columns[i].visible && hasNextVisible);
 			}
 		}
 	}

--- a/WebCPP/Controls/ListView/ListViewItemView.cpp
+++ b/WebCPP/Controls/ListView/ListViewItemView.cpp
@@ -30,7 +30,7 @@ namespace web
 				columns[index]->detach();
 			columns[index] = view;
 
-			getLayout<GridLayout>()->addViewBefore(view, index + 1 < columns.size() ? columns[index + 1] : nullptr);
+			getLayout<GridLayout>()->addViewBefore(view, index + 1 < columns.size() ? columns[index + 1] : nullptr, (int)(index + 1));
 
 			item->listview()->onColumnViewChanged(this, index);
 		}


### PR DESCRIPTION
1. ListViewItem: When a visible column follows a hidden column, the cell would be drawn at wrong index, causing wrong placement and truncation.
2. ListViewHeader: Missing splitter when a visible column follows a hidden column.