### PR TITLE
Fix use-after-free crash when clicking after items are removed

### DIFF
--- a/WebCPP/Controls/ListView/ListView.cpp
+++ b/WebCPP/Controls/ListView/ListView.cpp
@@ -493,6 +493,15 @@ namespace web
 	{
 		if (item != root.get() && item->view)
 		{
+			if (item == curFocusItem)
+				curFocusItem = nullptr;
+			if (item == curSelectedItem)
+			{
+				curSelectedItem = nullptr;
+				if (selectionChanged)
+					selectionChanged();
+			}
+
 			if (item->isOpen())
 			{
 				for (ListViewItem* cur = item->firstChild(); cur != nullptr; cur = cur->nextSibling())


### PR DESCRIPTION
curFocusItem and curSelectedItem were not cleared in onItemDetached, leaving dangling pointers after clearList() or remove(). A subsequent click would call focusItem() which read curFocusItem->view from freed memory, producing a null vtable pointer and crashing with "null function" in WASM.